### PR TITLE
Fix creature consume range

### DIFF
--- a/Assets/Prefabs/Planets/Planet.prefab
+++ b/Assets/Prefabs/Planets/Planet.prefab
@@ -729,7 +729,7 @@ MonoBehaviour:
   - {fileID: 5440707293445505367, guid: 494f6d43e170e9145bc7865d243ee00b, type: 3}
   - {fileID: 1127315056602366, guid: 3a9df2c30188f10438112114dc22bae1, type: 3}
   - {fileID: 1240686429475702, guid: da33a1bfeaaabaa4597896ca7003b785, type: 3}
-  densityMultiplier: 0.000002
+  densityMultiplier: 0.00002
   isInstantiated: 0
   treeNr: 0
   bushNr: 0

--- a/Assets/Scripts/Ecosystem/Creature.cs
+++ b/Assets/Scripts/Ecosystem/Creature.cs
@@ -295,7 +295,7 @@ public class Creature : MonoBehaviour
         if (nearestResource != null && resourcePos != Vector3.zero)
         {
             // If the resource is within consume radius, consume it
-            if (IsCloseToDestination(resourcePos))
+            if (IsCloseToObject(resourcePos))
             {
                 if (DEBUG) Debug.Log("Found it " + Vector3.Distance(transform.position, nearestResource.transform.position) + " away");
                 atDestination = true;
@@ -320,7 +320,7 @@ public class Creature : MonoBehaviour
                     if (disable) nearestResource.GetComponent<Resource>().ConsumeResource();
                 }
             }
-            else if (Vector3.Distance(transform.position, resourcePos) > consumeRadius)
+            else
             {
                 atDestination = false;
                 destination = resourcePos;
@@ -360,7 +360,7 @@ public class Creature : MonoBehaviour
 
         if (nearestObject != null)
         {
-            if (IsCloseToDestination(nearestObject.transform.position))
+            if (IsCloseToObject(nearestObject.transform.position))
             {
                 atDestination = true;
                 breedingPartner = nearestObject.GetComponent<Creature>();
@@ -465,7 +465,7 @@ public class Creature : MonoBehaviour
 
     private void GotoPosition(Vector3 pos)
     {
-        if (!pos.Equals(Vector2.zero) && !IsCloseToDestination(pos))
+        if (!pos.Equals(Vector2.zero) && !IsCloseToObject(pos))
         {
             // Move the ridgidbody based on velocity
             rigidbody.MovePosition(transform.position + speed * Time.deltaTime * (pos - transform.position).normalized);
@@ -475,14 +475,11 @@ public class Creature : MonoBehaviour
             atDestination = true;
         }
     }
-
-    private bool IsCloseToDestination(Vector3 pos)
+    
+    private bool IsCloseToObject(Vector3 pos)
     {
-        Vector3 creatureToPlanetCenter = (planet.transform.position - transform.position);
-        Vector3 posToPlanetCenter = planet.transform.position - pos;
-
-        float angle = Vector3.Angle(creatureToPlanetCenter, posToPlanetCenter);
-        return angle < consumeRadius;
+        // Gets the smallest distance from collider to pos
+        return collider.bounds.SqrDistance(pos) < 0.15f;
     }
 
     private void Rotate()


### PR DESCRIPTION
Change calculation used when creatures are close to objects (resources or partners). This fixes the bug where creatures can consume food from far away. 