### PR TITLE
Turned one world position into object position in terrain shader

### DIFF
--- a/Assets/Materials/Terrain.shadergraph
+++ b/Assets/Materials/Terrain.shadergraph
@@ -7319,7 +7319,7 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     },
-    "m_Space": 2,
+    "m_Space": 0,
     "m_PositionSource": 0
 }
 


### PR DESCRIPTION
There was an issue where the planet directly became white when you where of the planet and having it turn back to normal when transitioning to the planet. This has now been fixed making the two models have the same terrain color independent if you are on or of the planets.